### PR TITLE
(Dis)connect MediaBrowser based on ProcessLifecycleOwner

### DIFF
--- a/app/src/main/java/fr/nihilus/music/library/MusicLibraryViewModel.kt
+++ b/app/src/main/java/fr/nihilus/music/library/MusicLibraryViewModel.kt
@@ -43,7 +43,6 @@ class MusicLibraryViewModel @Inject constructor(
     val playerError: LiveData<Event<CharSequence>> = _playerError
 
     init {
-        client.connect()
         client.playbackState.onEach {
             when (it.state) {
                 PlaybackStateCompat.STATE_NONE,
@@ -70,10 +69,5 @@ class MusicLibraryViewModel @Inject constructor(
         viewModelScope.launch {
             client.playFromMediaId(playableMedia.mediaId.parse())
         }
-    }
-
-    override fun onCleared() {
-        client.disconnect()
-        super.onCleared()
     }
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -35,9 +35,7 @@ dependencies {
     api(libs.androidx.palette)
 
     // Android Arch Components
-    api(libs.androidx.lifecycle.livedata)
-    api(libs.androidx.lifecycle.viewmodel)
-    api(libs.androidx.lifecycle.runtime)
+    api(libs.bundles.androidx.lifecycle)
 
     // Navigation Components
     api(libs.androidx.navigation.fragment)

--- a/core-ui/src/main/java/fr/nihilus/music/core/ui/client/ApplicationLifecycle.kt
+++ b/core-ui/src/main/java/fr/nihilus/music/core/ui/client/ApplicationLifecycle.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Thibault Seisel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.nihilus.music.core.ui.client
+
+import javax.inject.Qualifier
+
+/**
+ * Denotes that a provided value is tied to the lifecycle of the whole application.
+ * This is currently only used to provide an instance of [androidx.lifecycle.Lifecycle].
+ */
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
+annotation class ApplicationLifecycle

--- a/core-ui/src/main/java/fr/nihilus/music/core/ui/client/BrowserClient.kt
+++ b/core-ui/src/main/java/fr/nihilus/music/core/ui/client/BrowserClient.kt
@@ -49,20 +49,6 @@ interface BrowserClient {
     val repeatMode: StateFlow<Int>
 
     /**
-     * Initiate connection to the media browser.
-     * Operations on the Media Session are only available once the media browser is connected.
-     *
-     * Make sure to [disconnect] from the media browser when it is no longer needed
-     * to avoid wasting resources.
-     */
-    fun connect()
-
-    /**
-     * Disconnects from the media browser.
-     */
-    fun disconnect()
-
-    /**
      * Retrieve children of a specified browsable item from the media browser tree,
      * observing changes to those children.
      * The latest value emitted by the returned flow is always the latest up-to-date children.

--- a/core-ui/src/main/java/fr/nihilus/music/core/ui/dagger/CoreUiModule.kt
+++ b/core-ui/src/main/java/fr/nihilus/music/core/ui/dagger/CoreUiModule.kt
@@ -16,10 +16,14 @@
 
 package fr.nihilus.music.core.ui.dagger
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import fr.nihilus.music.core.ui.client.ApplicationLifecycle
 import fr.nihilus.music.core.ui.client.BrowserClient
 import fr.nihilus.music.core.ui.client.BrowserClientImpl
 
@@ -33,4 +37,9 @@ abstract class CoreUiModule {
 
     @Binds
     internal abstract fun bindsBrowserClient(impl: BrowserClientImpl): BrowserClient
+
+    companion object {
+        @Provides @ApplicationLifecycle
+        fun providesApplicationLifecycle(): Lifecycle = ProcessLifecycleOwner.get().lifecycle
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androi
 androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-media = { module = "androidx.media:media", version.ref = "androidx-media" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
@@ -95,3 +97,10 @@ timber = "com.jakewharton.timber:timber:5.0.1"
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [bundles]
+androidx-lifecycle = [
+    "androidx-lifecycle-runtime",
+    "androidx-lifecycle-livedata",
+    "androidx-lifecycle-viewmodel",
+    "androidx-lifecycle-java8",
+    "androidx-lifecycle-process"
+]


### PR DESCRIPTION
ProcessLifecycleOwner is more suitable than ViewModel to manage the MediaBrowser connection lifecycle.
ViewModel keeps MediaBrowser connected until Activity is destroyed,
ProcessLifecycleOwner disconnects whenever the app moves to the background,
which is more efficient.