### PR TITLE
Use Gradle typesafe project accessors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,15 +118,15 @@ android {
 
 dependencies {
     // Sub-project containing the Media Service.
-    implementation(project(":core"))
-    implementation(project(":core-ui"))
-    implementation(project(":media"))
-    implementation(project(":service"))
-    implementation(project(":spotify-client"))
+    implementation(projects.core)
+    implementation(projects.coreUi)
+    implementation(projects.media)
+    implementation(projects.service)
+    implementation(projects.spotifyClient)
 
-    implementation(project(":ui-cleanup"))
-    implementation(project(":ui-settings"))
-    implementation(project(":ui-library"))
+    implementation(projects.uiCleanup)
+    implementation(projects.uiSettings)
+    implementation(projects.uiLibrary)
 
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
@@ -136,7 +136,7 @@ dependencies {
 
     implementation(libs.androidx.hilt.work)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 
     androidTestImplementation(libs.bundles.testing.instrumented)

--- a/core-database/build.gradle.kts
+++ b/core-database/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
     testImplementation(libs.bundles.testing.unit)
 
-    androidTestImplementation(project(":core-instrumentation"))
+    androidTestImplementation(projects.coreInstrumentation)
     androidTestImplementation(libs.bundles.testing.instrumented)
     androidTestImplementation(libs.androidx.room.testing)
 

--- a/core-test/build.gradle.kts
+++ b/core-test/build.gradle.kts
@@ -21,6 +21,6 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
+    implementation(projects.core)
     implementation(libs.bundles.testing.unit)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-database"))
-    implementation(project(":media"))
+    implementation(projects.core)
+    implementation(projects.coreDatabase)
+    implementation(projects.media)
 
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
@@ -35,7 +35,7 @@ dependencies {
 
     kapt(libs.glide.compiler)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 
     androidTestImplementation(libs.bundles.testing.instrumented)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     testImplementation(libs.bundles.testing.unit)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
 
-    androidTestImplementation(project(":core-instrumentation"))
+    androidTestImplementation(projects.coreInstrumentation)
     androidTestImplementation(libs.bundles.testing.instrumented)
     androidTestImplementation(libs.hilt.android.testing)
     kaptAndroidTest(libs.hilt.compiler)

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -23,10 +23,10 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-database"))
+    implementation(projects.core)
+    implementation(projects.coreDatabase)
     implementation(libs.bundles.core)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -25,17 +25,17 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-database"))
-    implementation(project(":media"))
-    implementation(project(":spotify-client"))
+    implementation(projects.core)
+    implementation(projects.coreDatabase)
+    implementation(projects.media)
+    implementation(projects.spotifyClient)
 
     implementation(libs.bundles.core)
     implementation(libs.androidx.media)
     implementation(libs.glide)
     implementation(libs.exoplayer.core)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 
     androidTestImplementation(libs.bundles.testing.instrumented)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
     repositories {
         gradlePluginPortal()

--- a/spotify-client/build.gradle.kts
+++ b/spotify-client/build.gradle.kts
@@ -34,9 +34,9 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-database"))
-    implementation(project(":media"))
+    implementation(projects.core)
+    implementation(projects.coreDatabase)
+    implementation(projects.media)
 
     implementation(libs.bundles.core)
     implementation(libs.ktor.client.okhttp)
@@ -49,7 +49,7 @@ dependencies {
     implementation(libs.androidx.hilt.work)
     kapt(libs.androidx.hilt.compiler)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
     testImplementation(libs.ktor.client.mock)
 }

--- a/ui-cleanup/build.gradle.kts
+++ b/ui-cleanup/build.gradle.kts
@@ -29,14 +29,14 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-ui"))
-    implementation(project(":media"))
+    implementation(projects.core)
+    implementation(projects.coreUi)
+    implementation(projects.media)
 
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
     implementation(libs.bundles.androidx.lifecycle)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 }

--- a/ui-library/build.gradle.kts
+++ b/ui-library/build.gradle.kts
@@ -29,9 +29,9 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-ui"))
-    implementation(project(":media"))
+    implementation(projects.core)
+    implementation(projects.coreUi)
+    implementation(projects.media)
 
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
@@ -39,6 +39,6 @@ dependencies {
     implementation(libs.androidx.viewpager)
     implementation(libs.androidx.media)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 }

--- a/ui-settings/build.gradle.kts
+++ b/ui-settings/build.gradle.kts
@@ -29,11 +29,11 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":core-database"))
-    implementation(project(":media"))
-    implementation(project(":core-ui"))
-    implementation(project(":spotify-client"))
+    implementation(projects.core)
+    implementation(projects.coreDatabase)
+    implementation(projects.media)
+    implementation(projects.coreUi)
+    implementation(projects.spotifyClient)
 
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
@@ -41,6 +41,6 @@ dependencies {
     implementation(libs.androidx.preference)
     implementation(libs.androidx.work.runtime)
 
-    testImplementation(project(":core-test"))
+    testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)
 }


### PR DESCRIPTION
This change enables an experimental feature of Gradle that exposes the list of subprojects in a typesafe way.