### PR TITLE
Migrate to androidx.media3 ExoPlayer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-fragment = "1.5.7"
 androidx-hilt = "1.0.0"
 androidx-lifecycle = "2.6.1"
 androidx-media = "1.6.0"
+androidx-media3 = "1.0.1"
 androidx-navigation = "2.5.3"
 androidx-palette = "1.0.0"
 androidx-preference = "1.2.0"
@@ -18,7 +19,6 @@ androidx-test-junit = "1.1.5"
 androidx-viewpager = "1.0.0"
 androidx-work = "2.7.1"
 dagger = "2.45"
-exoplayer = "2.18.6"
 glide = "4.13.2"
 identikon = "1.0.0"
 kotest = "5.6.1"
@@ -61,6 +61,7 @@ androidx-lifecycle-java8 = { module = "androidx.lifecycle:lifecycle-common-java8
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidx-lifecycle" }
 androidx-media = { module = "androidx.media:media", version.ref = "androidx-media" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-palette = { module = "androidx.palette:palette-ktx", version.ref = "androidx-palette" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
@@ -75,8 +76,6 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-viewpager = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager" }
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
-
-exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
 
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
 
     implementation(libs.bundles.core)
     implementation(libs.androidx.media)
+    implementation(libs.androidx.media3.exoplayer)
     implementation(libs.glide)
-    implementation(libs.exoplayer.core)
 
     testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)

--- a/service/src/main/java/fr/nihilus/music/service/MediaSessionConnector.kt
+++ b/service/src/main/java/fr/nihilus/music/service/MediaSessionConnector.kt
@@ -19,17 +19,17 @@ package fr.nihilus.music.service
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.core.util.component1
 import androidx.core.util.component2
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.util.ErrorMessageProvider
-import com.google.android.exoplayer2.util.Util
+import androidx.media3.common.C
+import androidx.media3.common.ErrorMessageProvider
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
 import dagger.hilt.android.scopes.ServiceScoped
 import fr.nihilus.music.media.AudioTrack
 import fr.nihilus.music.service.metadata.IconDownloader
@@ -85,7 +85,7 @@ internal class MediaSessionConnector @Inject constructor(
     private val errorMessageProvider: ErrorMessageProvider<PlaybackException>,
     private val iconDownloader: IconDownloader
 ) {
-    private val looper = Util.getCurrentOrMainLooper()
+    private val looper = Looper.myLooper() ?: Looper.getMainLooper()
     private val componentListener = ComponentListener()
 
     private val metadataProducer = scope.startMetadataUpdater()

--- a/service/src/main/java/fr/nihilus/music/service/MediaSessionModule.kt
+++ b/service/src/main/java/fr/nihilus/music/service/MediaSessionModule.kt
@@ -20,8 +20,8 @@ import android.app.PendingIntent
 import android.app.Service
 import android.support.v4.media.RatingCompat
 import android.support.v4.media.session.MediaSessionCompat
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.util.ErrorMessageProvider
+import androidx.media3.common.ErrorMessageProvider
+import androidx.media3.common.PlaybackException
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/service/src/main/java/fr/nihilus/music/service/MusicService.kt
+++ b/service/src/main/java/fr/nihilus/music/service/MusicService.kt
@@ -35,8 +35,8 @@ import android.support.v4.media.session.PlaybackStateCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.media.MediaBrowserServiceCompat
 import androidx.media.utils.MediaConstants
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.C
+import androidx.media3.common.Player
 import dagger.hilt.android.AndroidEntryPoint
 import fr.nihilus.music.core.context.AppDispatchers
 import fr.nihilus.music.core.media.MalformedMediaIdException
@@ -443,7 +443,7 @@ class MusicService : BaseBrowserService() {
     private inner class TrackCompletionListener : Player.Listener {
 
         override fun onMediaItemTransition(
-            mediaItem: com.google.android.exoplayer2.MediaItem?,
+            mediaItem: androidx.media3.common.MediaItem?,
             @Player.MediaItemTransitionReason reason: Int
         ) {
             if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {

--- a/service/src/main/java/fr/nihilus/music/service/MusicServiceModule.kt
+++ b/service/src/main/java/fr/nihilus/music/service/MusicServiceModule.kt
@@ -16,8 +16,8 @@
 
 package fr.nihilus.music.service
 
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/service/src/main/java/fr/nihilus/music/service/extensions/ExoPlayerExt.kt
+++ b/service/src/main/java/fr/nihilus/music/service/extensions/ExoPlayerExt.kt
@@ -16,9 +16,9 @@
 
 package fr.nihilus.music.service.extensions
 
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.Timeline
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.ExoPlayer
 
 /**
  * Execute the given action once when the structure of media has changed.

--- a/service/src/main/java/fr/nihilus/music/service/playback/AudioOnlyExtractorsFactory.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/AudioOnlyExtractorsFactory.kt
@@ -16,16 +16,18 @@
 
 package fr.nihilus.music.service.playback
 
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
-import com.google.android.exoplayer2.extractor.Extractor
-import com.google.android.exoplayer2.extractor.ExtractorsFactory
-import com.google.android.exoplayer2.extractor.flac.FlacExtractor
-import com.google.android.exoplayer2.extractor.mp3.Mp3Extractor
-import com.google.android.exoplayer2.extractor.mp4.Mp4Extractor
-import com.google.android.exoplayer2.extractor.ogg.OggExtractor
-import com.google.android.exoplayer2.extractor.ts.Ac3Extractor
-import com.google.android.exoplayer2.extractor.ts.AdtsExtractor
-import com.google.android.exoplayer2.extractor.wav.WavExtractor
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.Extractor
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.extractor.flac.FlacExtractor
+import androidx.media3.extractor.mp3.Mp3Extractor
+import androidx.media3.extractor.mp4.Mp4Extractor
+import androidx.media3.extractor.ogg.OggExtractor
+import androidx.media3.extractor.ts.Ac3Extractor
+import androidx.media3.extractor.ts.AdtsExtractor
+import androidx.media3.extractor.wav.WavExtractor
 
 /**
  * An ExtractorsFactory that only uses audio file extractors.
@@ -36,6 +38,7 @@ import com.google.android.exoplayer2.extractor.wav.WavExtractor
  * The full explanation is detailed
  * on the [ExoPlayer official documentation](https://google.github.io/ExoPlayer/shrinking.html).
  */
+@OptIn(UnstableApi::class)
 internal class AudioOnlyExtractorsFactory : ExtractorsFactory {
 
     override fun createExtractors() = arrayOf(

--- a/service/src/main/java/fr/nihilus/music/service/playback/AudioOnlyRenderersFactory.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/AudioOnlyRenderersFactory.kt
@@ -18,15 +18,17 @@ package fr.nihilus.music.service.playback
 
 import android.content.Context
 import android.os.Handler
-import com.google.android.exoplayer2.DefaultRenderersFactory
-import com.google.android.exoplayer2.Renderer
-import com.google.android.exoplayer2.RenderersFactory
-import com.google.android.exoplayer2.audio.AudioRendererEventListener
-import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer
-import com.google.android.exoplayer2.mediacodec.MediaCodecSelector
-import com.google.android.exoplayer2.metadata.MetadataOutput
-import com.google.android.exoplayer2.text.TextOutput
-import com.google.android.exoplayer2.video.VideoRendererEventListener
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.metadata.MetadataOutput
+import androidx.media3.exoplayer.text.TextOutput
+import androidx.media3.exoplayer.video.VideoRendererEventListener
 
 /**
  * A [RenderersFactory] implementation that only uses the audio renderer.
@@ -37,6 +39,7 @@ import com.google.android.exoplayer2.video.VideoRendererEventListener
  * The full explanation is detailed on the
  * [ExoPlayer official documentation](https://google.github.io/ExoPlayer/shrinking.html).
  */
+@OptIn(UnstableApi::class)
 internal class AudioOnlyRenderersFactory(private val context: Context) : RenderersFactory {
 
     override fun createRenderers(

--- a/service/src/main/java/fr/nihilus/music/service/playback/ErrorHandler.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/ErrorHandler.kt
@@ -19,8 +19,8 @@ package fr.nihilus.music.service.playback
 import android.content.Context
 import android.support.v4.media.session.PlaybackStateCompat
 import android.util.Pair
-import com.google.android.exoplayer2.PlaybackException
-import com.google.android.exoplayer2.util.ErrorMessageProvider
+import androidx.media3.common.ErrorMessageProvider
+import androidx.media3.common.PlaybackException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 import fr.nihilus.music.service.R

--- a/service/src/main/java/fr/nihilus/music/service/playback/MediaQueueManager.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/MediaQueueManager.kt
@@ -19,9 +19,9 @@ package fr.nihilus.music.service.playback
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.Timeline
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import dagger.hilt.android.scopes.ServiceScoped
 import fr.nihilus.music.core.settings.Settings
 import fr.nihilus.music.media.AudioTrack

--- a/service/src/main/java/fr/nihilus/music/service/playback/OdeonPlaybackPreparer.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/OdeonPlaybackPreparer.kt
@@ -22,10 +22,12 @@ import android.os.Bundle
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import android.util.Log
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.source.ShuffleOrder
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ShuffleOrder
 import fr.nihilus.music.core.context.AppDispatchers
 import fr.nihilus.music.core.media.MediaId
 import fr.nihilus.music.core.media.MediaId.Builder.CATEGORY_ALL
@@ -51,6 +53,7 @@ import kotlin.random.Random
  * Handle requests to prepare media that can be played from the Odeon Media Player.
  * This fetches media information from the music library.
  */
+@OptIn(UnstableApi::class)
 internal class OdeonPlaybackPreparer @Inject constructor(
     @ServiceCoroutineScope private val scope: CoroutineScope,
     private val dispatchers: AppDispatchers,

--- a/service/src/main/java/fr/nihilus/music/service/playback/PlaybackModule.kt
+++ b/service/src/main/java/fr/nihilus/music/service/playback/PlaybackModule.kt
@@ -17,11 +17,13 @@
 package fr.nihilus.music.service.playback
 
 import android.app.Service
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.audio.AudioAttributes
-import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
-import com.google.android.exoplayer2.util.EventLogger
+import androidx.annotation.OptIn
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.util.EventLogger
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -31,6 +33,7 @@ import fr.nihilus.music.service.BuildConfig
 
 @Module
 @InstallIn(ServiceComponent::class)
+@OptIn(UnstableApi::class)
 internal object PlaybackModule {
 
     @Provides @ServiceScoped


### PR DESCRIPTION
The ExoPlayer library has been discontinued in favor of the equivalent androidx.media3.exoplayer package.